### PR TITLE
Fix the logic in DWARFContext thread safety selection

### DIFF
--- a/llvm/lib/DebugInfo/DWARF/DWARFContext.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFContext.cpp
@@ -734,7 +734,7 @@ DWARFContext::DWARFContext(std::unique_ptr<const DWARFObject> DObj,
     : DIContext(CK_DWARF),
       RecoverableErrorHandler(RecoverableErrorHandler),
       WarningHandler(WarningHandler), DObj(std::move(DObj)) {
-        if (ThreadSafe)
+        if (!ThreadSafe)
           State.reset(new ThreadUnsafeDWARFContextState(*this, DWPName));
         else
           State.reset(new ThreadSafeState(*this, DWPName));


### PR DESCRIPTION
The patch triggered some TSAN reports. Looks like the logic which decided if the thread safe or thread unsafe implementation should be used is inverted. The test is passing with this patch in place.